### PR TITLE
 Store and use auth tokens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'rake'
 
 # Debugging
 gem 'pry'
+gem 'rack-test'
 
 # Communication
 gem 'http'
@@ -40,6 +41,5 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rack-test'
   gem 'rerun'
 end

--- a/app/controllers/account.rb
+++ b/app/controllers/account.rb
@@ -10,7 +10,7 @@ module TimeCapsule
       routing.on do
         # GET /account/
         routing.get String do |username|
-          if @current_account && @current_account['username'] == username
+          if @current_account && @current_account.username == username
             view :account, locals: { current_account: @current_account }
           else
             routing.redirect '/auth/login'

--- a/app/controllers/app.rb
+++ b/app/controllers/app.rb
@@ -14,7 +14,7 @@ module TimeCapsule
 
     route do |routing|
       response['Content-Type'] = 'text/html; charset=utf-8'
-      @current_account = SecureSession.new(session).get(:current_account)
+      @current_account = CurrentSession.new(session).current_account
 
       routing.public
       routing.assets
@@ -22,6 +22,8 @@ module TimeCapsule
 
       # GET /
       routing.root do
+        # test: get all capsules if an account logged in
+        GetAllCapsules.new(App.config).call(@current_account) if @current_account.logged_in?
         view 'home', locals: { current_account: @current_account }
       end
     end

--- a/app/controllers/auth.rb
+++ b/app/controllers/auth.rb
@@ -16,16 +16,22 @@ module TimeCapsule
 
         # POST /auth/login
         routing.post do
-          account = AuthenticateAccount.new(App.config).call(
+          account_info = AuthenticateAccount.new(App.config).call(
             username: routing.params['username'],
             password: routing.params['password']
           )
-          SecureSession.new(session).set(:current_account, account)
-          flash[:notice] = "Welcome back #{account['username']}!"
+          current_account = Account.new(
+            account_info['account'],
+            account_info['auth_token']
+          )
+
+          CurrentSession.new(session).current_account = current_account
+
+          flash[:notice] = "Welcome back #{current_account.username}!"
           routing.redirect '/'
         rescue AuthenticateAccount::UnauthorizedError
           flash.now[:error] = 'Username and password did not match our records'
-          response.status = 400
+          response.status = 401
           view :login
         rescue AuthenticateAccount::ApiServerError => e
           App.logger.warn "API server error: #{e.inspect}\n#{e.backtrace}"
@@ -38,34 +44,36 @@ module TimeCapsule
       @logout_route = '/auth/logout'
       routing.on 'logout' do
         routing.get do
-          SecureSession.new(session).delete(:current_account)
+          CurrentSession.new(session).delete
           flash[:notice] = "You've been logged out"
           routing.redirect @login_route
         end
       end
 
       @register_route = '/auth/register'
-      routing.is 'register' do
-        # GET /auth/register
-        routing.get do
-          view :register
-        end
+      routing.on 'register' do
+        routing.is do
+          # GET /auth/register
+          routing.get do
+            view :register
+          end
 
-        # POST /auth/register
-        routing.post do
-          account_data = JsonRequestBody.symbolize(routing.params)
-          VerifyRegistration.new(App.config).call(account_data)
+          # POST /auth/register
+          routing.post do
+            account_data = JsonRequestBody.symbolize(routing.params)
+            VerifyRegistration.new(App.config).call(account_data)
 
-          flash[:notice] = 'Please check your email for a verification link'
-          routing.redirect '/'
-        rescue VerifyRegistration::ApiServerError => e
-          App.logger.warn "API server error: #{e.inspect}\n#{e.backtrace}"
-          flash[:error] = 'Our servers are not responding -- please try later'
-          routing.redirect @register_route
-        rescue StandardError => e
-          App.logger.error "Could not verify registration: #{e.inspect} / account_data: #{account_data}"
-          flash[:error] = 'Registration details are not valid'
-          routing.redirect @register_route
+            flash[:notice] = 'Please check your email for a verification link'
+            routing.redirect '/'
+          rescue VerifyRegistration::ApiServerError => e
+            App.logger.warn "API server error: #{e.inspect}\n#{e.backtrace}"
+            flash[:error] = 'Our servers are not responding -- please try later'
+            routing.redirect @register_route
+          rescue StandardError => e
+            App.logger.error "Could not verify registration: #{e.inspect}"
+            flash[:error] = 'Registration details are not valid'
+            routing.redirect @register_route
+          end
         end
 
         # GET /auth/register/<token>

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module TimeCapsule
+  # Behaviors of the currently logged in account
+  class Account
+    def initialize(account_info, auth_token)
+      @account_info = account_info
+      @auth_token = auth_token
+    end
+
+    attr_reader :account_info, :auth_token
+
+    def username
+      @account_info ? @account_info['username'] : nil
+    end
+
+    def email
+      @account_info ? @account_info['email'] : nil
+    end
+
+    def logged_out?
+      @account_info.nil?
+    end
+
+    def logged_in?
+      !logged_out?
+    end
+  end
+end

--- a/app/models/current_session.rb
+++ b/app/models/current_session.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative './account'
+
+module TimeCapsule
+  # Managing session information
+  class CurrentSession
+    def initialize(session)
+      @secure_session = SecureSession.new(session)
+    end
+
+    def current_account
+      Account.new(@secure_session.get(:account),
+                  @secure_session.get(:auth_token))
+    end
+
+    def current_account=(current_account)
+      @secure_session.set(:account, current_account.account_info)
+      @secure_session.set(:auth_token, current_account.auth_token)
+    end
+
+    def delete
+      @secure_session.delete(:account)
+      @secure_session.delete(:auth_token)
+    end
+  end
+end

--- a/app/presentation/views/nav.slim
+++ b/app/presentation/views/nav.slim
@@ -8,15 +8,15 @@ nav role="navigation" class="navbar navbar-expand-sm navbar-dark bg-primary"
 
     div class="collapse navbar-collapse" id="mainNavbar"
       ul class="navbar-nav me-auto"
-        - if @current_account
+        - if @current_account.logged_in?
           li class="nav-item"
             a class="nav-link disabled" href="/" Capsule
           li class="nav-item dropdown"
             a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"
-              = "#{@current_account['username']}"
+              = "#{@current_account.username}"
 
             div class=-"dropdown-menu"
-              a class="dropdown-item" href="/account/#{@current_account['username']}" account
+              a class="dropdown-item" href="/account/#{@current_account.username}" account
               a class="dropdown-item" href='/auth/logout' logout
         - else
           li class="nav-item"

--- a/app/services/authenticate_account.rb
+++ b/app/services/authenticate_account.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'http'
-require 'pry'
 
 module TimeCapsule
   # Returns an authenticated user, or nil
@@ -17,16 +16,10 @@ module TimeCapsule
     def call(username:, password:)
       response = HTTP.post("#{@config.API_URL}/auth/authenticate",
                            json: { username:, password: })
-      raise(UnauthorizedError) unless response.code == 200
+      raise(UnauthorizedError) if response.code == 403
       raise(ApiServerError) if response.code != 200
 
-      account_info = JSON.parse(response.to_s)['attributes']
-
-      { account: account_info['account']['attributes'],
-        auth_token: account_info['auth_token'] }
-
-    rescue HTTP::ConnectionError
-      raise ApiServerError
+      response.parse['attributes']
     end
   end
 end

--- a/app/services/get_all_capsules.rb
+++ b/app/services/get_all_capsules.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'http'
+
+# Returns all capsules belonging to an account
+class GetAllCapsules
+  def initialize(config)
+    @config = config
+  end
+
+  def call(current_account)
+    response = HTTP.auth("Bearer #{current_account.auth_token}")
+                   .get("#{@config.API_URL}/capsules")
+    response.code == 200 ? JSON.parse(response.to_s)['data'] : nil
+  end
+end

--- a/config/environments.rb
+++ b/config/environments.rb
@@ -47,8 +47,10 @@ module TimeCapsule
     end
 
     configure :development, :test do
+      require 'pry'
+
       # NOTE: REDIS_URL only used to wipe the session store (ok to be nil)
-      SecureSession.setup(ENV.fetch('REDIS_URL')) # REDIS_URL used again below
+      SecureSession.setup(ENV.fetch('REDIS_URL', nil)) # REDIS_URL used again below
 
       # use Rack::Session::Cookie,
       #     expire_after: ONE_MONTH, secret: config.SESSION_SECRET

--- a/require_app.rb
+++ b/require_app.rb
@@ -7,7 +7,7 @@
 #  require_app
 #  require_app('config')
 #  require_app(['config', 'models'])
-def require_app(folders = %w[services controllers])
+def require_app(folders = %w[lib models services controllers])
   app_list = Array(folders).map { |folder| "app/#{folder}" }
   full_list = ['config', app_list].flatten.join(',')
   Dir.glob("./{#{full_list}}/**/*.rb").each do |file|

--- a/spec/fixtures/auth_account.json
+++ b/spec/fixtures/auth_account.json
@@ -1,0 +1,1 @@
+{"type":"authenticated_account","attributes":{"account":{"type":"account","attributes":{"username":"emily.liu","email":"eliu@nthu.edu.tw"}},"auth_token":"JjTEFlxytEhBlO1jG_4NV29qJGR2Ypvzo-EEHwBgAFWHfMD0FkCW4G_yiH-CjmJiZD5EYyh-mfSE-RC6YE0wJJOUKJ8lUwTHmmpcHs64z3jni6RPMVNiXK0nXX1m9nuVMIvRmhK8YV2qppwCYad-SiEna5q0zal4Vtt1qprQKcc1c9cy4ZIVw_aPrtlddI4t-00="}}

--- a/spec/integration/service_authenticate_spec.rb
+++ b/spec/integration/service_authenticate_spec.rb
@@ -5,10 +5,9 @@ require 'webmock/minitest'
 
 describe 'Test Service Objects' do
   before do
-    @credentials = { username: 'jessica.huang', password: 'randompass' }
-    @mal_credentials = { username: 'jessica.huang', password: 'wrongpassword' }
-    @api_account = { attributes:
-                       { username: 'jessica.huang', email: 'jhuang@nthu.edu.tw' } }
+    @credentials = { username: 'emily.liu', password: 'mypa$$w0rd' }
+    @mal_credentials = { username: 'emily.liu', password: 'wrongpassword' }
+    @api_account = { username: 'emily.liu', email: 'eliu@nthu.edu.tw' }
   end
 
   after do
@@ -17,16 +16,26 @@ describe 'Test Service Objects' do
 
   describe 'Find authenticated account' do
     it 'HAPPY: should find an authenticated account' do
+      auth_account_file = 'spec/fixtures/auth_account.json'
+      ## Use this code to get an actual seeded account from API:
+      # response = HTTP.post("#{app.config.API_URL}/auth/authenticate",
+      #   json: { username: @credentials[:username], password: @credentials[:password] })
+      # auth_account_json = response.body.to_s
+      # File.write(auth_account_file, auth_account_json)
+
+      auth_return_json = File.read(auth_account_file)
+
       WebMock.stub_request(:post, "#{API_URL}/auth/authenticate")
              .with(body: @credentials.to_json)
-             .to_return(body: @api_account.to_json,
+             .to_return(body: auth_return_json,
                         headers: { 'content-type' => 'application/json' })
 
-      account = TimeCapsule::AuthenticateAccount.new(app.config).call(**@credentials)
+      auth = TimeCapsule::AuthenticateAccount.new(app.config).call(**@credentials)
 
+      account = auth['account']['attributes']
       _(account).wont_be_nil
-      _(account['attributes']['username']).must_equal @api_account[:attributes][:username]
-      _(account['attributes']['email']).must_equal @api_account[:attributes][:email]
+      _(account['username']).must_equal @api_account[:username]
+      _(account['email']).must_equal @api_account[:email]
     end
 
     it 'BAD: should not find a false authenticated account' do


### PR DESCRIPTION
1. Create an Account model to store logged in accounts information and auth token. 
2. Create a CurrentSession model to store both account information and tokens in secure session.
3. Send auth token to API in every request as HTTP_AUTHENTICATION header: 'Bearer <TOKEN>'