### PR TITLE
Sign critical requests

### DIFF
--- a/app/controllers/capsules.rb
+++ b/app/controllers/capsules.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'roda'
+require_relative './app'
 
 module TimeCapsule
   # rubocop:disable Metrics/ClassLength

--- a/app/controllers/letters.rb
+++ b/app/controllers/letters.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'roda'
+require_relative './app'
 
 module TimeCapsule
   # Web controller for TimeCapsule API

--- a/app/lib/signed_message.rb
+++ b/app/lib/signed_message.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'rbnacl'
+
+# Encrypt and Decrypt from Database
+class SignedMessage
+  # Call setup once to pass in config variable with SIGNING_KEY attribute
+  def self.setup(config)
+    @signing_key = Base64.strict_decode64(config.SIGNING_KEY)
+  end
+
+  def self.sign(message)
+    signature = RbNaCl::SigningKey.new(@signing_key)
+                                  .sign(message.to_json)
+                                  .then { |sig| Base64.strict_encode64(sig) }
+
+    { data: message, signature: }
+  end
+end

--- a/app/services/authenticate_account.rb
+++ b/app/services/authenticate_account.rb
@@ -14,16 +14,18 @@ module TimeCapsule
     end
 
     def call(username:, password:)
+      credentials = { username:, password: }
+
       response = HTTP.post("#{@config.API_URL}/auth/authenticate",
-                           json: { username:, password: })
+                           json: SignedMessage.sign(credentials))
+
       raise(UnauthorizedError) if response.code == 403
       raise(ApiServerError) if response.code != 200
 
       account_info = JSON.parse(response.to_s)['attributes']
-      {
-        account: account_info['account'],
-        auth_token: account_info['auth_token']
-      }
+      
+      { account: account_info['account'],
+        auth_token: account_info['auth_token'] }
     end
   end
 end

--- a/app/services/authorize_github_account.rb
+++ b/app/services/authorize_github_account.rb
@@ -38,19 +38,21 @@ module TimeCapsule
     end
 
     def get_sso_account_from_api(access_token)
-      response =
-        HTTP.post("#{@config.API_URL}/auth/sso",
-                  json: { access_token: })
+      signed_sso_info = { access_token: }
+                        .then { |sso_info| SignedMessage.sign(sso_info) }
+
+      response = HTTP.post(
+        "#{@config.API_URL}/auth/sso",
+        json: signed_sso_info
+      )
       raise(ReuseEmailError) if response.code == 400
       raise if response.code > 400
 
       account_info = JSON.parse(response)['data']['attributes']
-      {
-        account: account_info['account'],
+      { account: account_info['account'],
         auth_token: account_info['auth_token'],
         account_id: account_info['account_id'],
-        is_register: account_info['is_register']
-      }
+        is_register: account_info['is_register'] }
     end
   end
 end

--- a/app/services/create_account.rb
+++ b/app/services/create_account.rb
@@ -15,12 +15,11 @@ module TimeCapsule
     end
 
     def call(email:, username:, password:)
-      message = { email:,
-                  username:,
-                  password: }
+      account = { email:, username:, password: }
+
       response = HTTP.post(
         "#{@config.API_URL}/accounts/",
-        json: message
+        json: SignedMessage.sign(account)
       )
       raise InvalidAccount unless response.code == 201
 

--- a/app/services/verify_registration.rb
+++ b/app/services/verify_registration.rb
@@ -19,7 +19,7 @@ module TimeCapsule
         "#{@config.APP_URL}/auth/register/#{registration_token}"
 
       response = HTTP.post("#{@config.API_URL}/auth/register",
-                           json: registration_data)
+                           json: SignedMessage.sign(registration_data))
       raise(ReuseEmailOrUsernameError) if response.code == 400
       raise(VerificationError) unless response.code == 202
 

--- a/config/environments.rb
+++ b/config/environments.rb
@@ -30,12 +30,16 @@ module TimeCapsule
 
     configure do
       SecureMessage.setup(ENV.delete('MSG_KEY'))
+      SignedMessage.setup(config)
     end
-
+    
     configure :production do
       SecureSession.setup(ENV.fetch('REDIS_TLS_URL')) # REDIS_TLS_URL used again below
+      
       use Rack::Session::Redis,
           expire_after: ONE_MONTH,
+          httponly: true,
+          same_site: :strict,
           redis_server: {
             url: ENV.delete('REDIS_TLS_URL'),
             ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
@@ -43,19 +47,23 @@ module TimeCapsule
     end
 
     configure :development, :test do
-      require 'pry'
-
-      # NOTE: REDIS_URL only used to wipe the session store (ok to be nil)
       SecureSession.setup(ENV.fetch('REDIS_URL', nil)) # REDIS_URL used again below
 
       # use Rack::Session::Cookie,
-      #     expire_after: ONE_MONTH, secret: config.SESSION_SECRET
+      #     expire_after: ONE_MONTH,
+      #     secret: config.SESSION_SECRET,
+      #     httponly: true,
+      #     same_site: :strict
 
       use Rack::Session::Pool,
-          expire_after: ONE_MONTH
+          expire_after: ONE_MONTH,
+          httponly: true,
+          same_site: :strict
 
       # use Rack::Session::Redis,
       #     expire_after: ONE_MONTH,
+      #     httponly: true,
+      #     same_site: :strict,
       #     redis_server: {
       #       url: ENV.delete('REDIS_URL')
       #     }

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -7,6 +7,8 @@ development:
   SESSION_SECRET: ND3mZpWrmpAEEjke2N7eJn65IrUPLtCxwYSaql1b0L0+LgaxMPik2Eb9DEYsNSV4SWC4FCOdKtsQ8IIangRYDQ==
   MSG_KEY: Ri5Jto03ZB60i6WWVlo9MnBE1Ivc27Lr1HwHckoWARI=
   REDIS_URL: <provision Redis instance; provide TLS rediss URL for production>
+  SIGNING_KEY: Y81DDN4V8U9jhSdr2wenyPxOnPZl/rOGcA9BgDa9b6M=
+  REDIS_TLS_URL: <provision Redis instance; provide redis URL for dev/test>
   GH_OAUTH_URL: https://github.com/login/oauth/authorize
   GH_TOKEN_URL: https://github.com/login/oauth/access_token
   GH_SCOPE: user:email
@@ -25,6 +27,8 @@ test:
   SESSION_SECRET: ND3mZpWrmpAEEjke2N7eJn65IrUPLtCxwYSaql1b0L0+LgaxMPik2Eb9DEYsNSV4SWC4FCOdKtsQ8IIangRYDQ==
   MSG_KEY: Ri5Jto03ZB60i6WWVlo9MnBE1Ivc27Lr1HwHckoWARI=
   REDIS_URL: <provision Redis instance; provide TLS rediss URL for production>
+  SIGNING_KEY: Y81DDN4V8U9jhSdr2wenyPxOnPZl/rOGcA9BgDa9b6M=
+  REDIS_TLS_URL: <provision Redis instance; provide redis URL for dev/test>
   GH_OAUTH_URL: https://github.com/login/oauth/authorize
   GH_TOKEN_URL: https://github.com/login/oauth/access_token
   GH_SCOPE: user:email
@@ -42,6 +46,7 @@ production:
   APP_URL: <provisioned app URL (root without ending slash)>
   SESSION_SECRET: ND3mZpWrmpAEEjke2N7eJn65IrUPLtCxwYSaql1b0L0+LgaxMPik2Eb9DEYsNSV4SWC4FCOdKtsQ8IIangRYDQ==
   MSG_KEY: Ri5Jto03ZB60i6WWVlo9MnBE1Ivc27Lr1HwHckoWARI=
+  SIGNING_KEY: <provision on API side through rake command>
   REDIS_URL: <provision Redis instance; provide TLS rediss URL for production>
   REDIS_TLS_URL: <provision Redis instance; provide TLS rediss URL for production>
   GH_OAUTH_URL: https://github.com/login/oauth/authorize

--- a/spec/integration/service_authenticate_spec.rb
+++ b/spec/integration/service_authenticate_spec.rb
@@ -26,7 +26,7 @@ describe 'Test Service Objects' do
       auth_return_json = File.read(auth_account_file)
 
       WebMock.stub_request(:post, "#{API_URL}/auth/authenticate")
-             .with(body: @credentials.to_json)
+             .with(body: SignedMessage.sign(@credentials).to_json)
              .to_return(body: auth_return_json,
                         headers: { 'content-type' => 'application/json' })
       auth = TimeCapsule::AuthenticateAccount.new(app.config).call(**@credentials)
@@ -39,7 +39,7 @@ describe 'Test Service Objects' do
 
     it 'BAD: should not find a false authenticated account' do
       WebMock.stub_request(:post, "#{API_URL}/auth/authenticate")
-             .with(body: @mal_credentials.to_json)
+             .with(body: SignedMessage.sign(@mal_credentials).to_json)
              .to_return(status: 403)
       _(proc {
         TimeCapsule::AuthenticateAccount.new(app.config).call(**@mal_credentials)


### PR DESCRIPTION
1. Create a `SignedMessage` library to sign messages using a signing key the API has created
2. Send your signed json requests with separate `data` and `signature` parts
